### PR TITLE
Fix link to David's info

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ DXC Digital Explorer is not a data lake, DXC Digital Explorer is a living datase
 
 ### :busts_in_silhouette: Contacts
 
-* Product Owner/Architect : [David Stevens](davidstevens@dxc.com)
+* Product Owner/Architect : [David Stevens](https://github.com/EnglishSid)


### PR DESCRIPTION
As it stands, the link to David's e-mail at the bottom of the README is broken - presents a GitHub 404.

It could be easily changed to become a `mailto:....@dxc.com` link, but driving up the collaboration and interaction, I think linking directly to your GitHub profile might be ideal. (what else does he contribute to? what does his bio say? etc)

In alignment, you may want to add your e-mail address to your GitHub profile as well, unless that was intentional to reduce spam. But I like linking in this way.